### PR TITLE
Graceful login rejection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 -----------
 
+* Let host app add a message when declining user login because of subsequent
+  validation done once the app receives the login event.
 * Switched over to github.com
 * Setup tests with tox and travis (but only for py27 and pypy)
 

--- a/pyramid_google_login/tests/functional/test_flow.py
+++ b/pyramid_google_login/tests/functional/test_flow.py
@@ -101,7 +101,7 @@ class TestCallback(ApiMockBase):
         from pyramid_google_login.events import UserLoggedIn
 
         def subscriber(event):
-            raise Exception('WTF')
+            raise Exception('What a terrible failure')
 
         self.config.add_subscriber(subscriber, UserLoggedIn)
         self.googleapi.get_user_id_from_userinfo.return_value = 'bob@bob.com'
@@ -117,13 +117,13 @@ class TestCallback(ApiMockBase):
         from pyramid_google_login.exceptions import AuthFailed
 
         def subscriber(event):
-            raise AuthFailed('WTF')
+            raise AuthFailed('What a terrible failure')
 
         self.config.add_subscriber(subscriber, UserLoggedIn)
         self.googleapi.get_user_id_from_userinfo.return_value = 'bob@bob.com'
 
         response = self.app.get('/auth/oauth2callback', status=302)
         self.assertIn(
-            'http://localhost/auth/signin?message=WTF',
+            'http://localhost/auth/signin?message=What+a+terrible+failure',
             response.headers.get('Location')
             )

--- a/pyramid_google_login/tests/functional/test_flow.py
+++ b/pyramid_google_login/tests/functional/test_flow.py
@@ -111,3 +111,19 @@ class TestCallback(ApiMockBase):
             'http://localhost/auth/signin?',
             response.headers.get('Location')
             )
+
+    def test_callback_with_subscriber_failing_auth(self):
+        from pyramid_google_login.events import UserLoggedIn
+        from pyramid_google_login.exceptions import AuthFailed
+
+        def subscriber(event):
+            raise AuthFailed('WTF')
+
+        self.config.add_subscriber(subscriber, UserLoggedIn)
+        self.googleapi.get_user_id_from_userinfo.return_value = 'bob@bob.com'
+
+        response = self.app.get('/auth/oauth2callback', status=302)
+        self.assertIn(
+            'http://localhost/auth/signin?message=WTF',
+            response.headers.get('Location')
+            )

--- a/pyramid_google_login/views.py
+++ b/pyramid_google_login/views.py
@@ -112,6 +112,8 @@ def callback(request):
     user_logged_in = UserLoggedIn(request, userid, oauth2_token, userinfo)
     try:
         request.registry.notify(user_logged_in)
+    except AuthFailed as e:
+        return redirect_to_signin(request, e.message)
     except:
         log.exception('Application crashed processing UserLoggedIn event'
                       '\nuserinfo=%s oauth2_token=%s',


### PR DESCRIPTION
Let host app add a message when declining user login because of subsequent validation done once the app receives the login event.
