### PR TITLE
Fix #10: Incompatibility with pyramid==1.10

### DIFF
--- a/pyramid_google_login/utility.py
+++ b/pyramid_google_login/utility.py
@@ -79,7 +79,7 @@ class ApiClient(object):
                 'Error from Google (%s)' % self.request.params['error'])
         try:
             code = self.request.params['code']
-        except KeyError as err:
+        except KeyError:
             raise AuthFailed('No authorization code from Google')
 
         params = {
@@ -98,7 +98,7 @@ class ApiClient(object):
         except RequestException as err:
             raise AuthFailed('Failed to get token from Google (%s)' % err)
 
-        except Exception as err:
+        except Exception:
             log.warning('Unkown error while calling token endpoint',
                         exc_info=True)
             raise AuthFailed('Failed to get token from Google (unkown error)')

--- a/pyramid_google_login/views.py
+++ b/pyramid_google_login/views.py
@@ -121,7 +121,7 @@ def callback(request):
     if user_logged_in.headers:
         headers = user_logged_in.headers
     else:
-        headers = remember(request, principal=userid)
+        headers = remember(request, userid)
     return HTTPFound(location=url, headers=headers)
 
 


### PR DESCRIPTION
A security function signature changed:

`remember(request, principal, **kwargs)`
to `remember(request, userid, **kwargs)`

* [PR: Pyramid 1.10 remove deprecated principal argument to
* remember](https://github.com/Pylons/pyramid/pull/3369).
* [Pyramid 1.10 backward
* incompatibilities](https://docs.pylonsproject.org/projects/pyramid/en/1.10-branch/whatsnew-1.10.html#backward-incompatibilities)